### PR TITLE
pair before connect

### DIFF
--- a/custom_components/blanco_unit/client.py
+++ b/custom_components/blanco_unit/client.py
@@ -482,6 +482,7 @@ class BlancoUnitBluetoothClient:
                 device=self._device,
                 name=self._device.name or "Unknown Device",
                 disconnected_callback=self._handle_disconnect,
+                pair=True,
                 timeout=120,
             )
 


### PR DESCRIPTION
- pairing before connecting seems to fix issues with blanco choice all (related https://github.com/Nailik/blanco_unit/issues/2)