### PR TITLE
remove device class battery from filter/co2 sensor

### DIFF
--- a/custom_components/blanco_unit/sensor.py
+++ b/custom_components/blanco_unit/sensor.py
@@ -86,6 +86,7 @@ class FilterRemainingSensor(BlancoUnitBaseEntity, SensorEntity):
 
     _attr_unique_id = "filter_remaining"
     _attr_translation_key = _attr_unique_id
+    _attr_icon = "mdi:history"
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -107,6 +108,7 @@ class CO2RemainingSensor(BlancoUnitBaseEntity, SensorEntity):
 
     _attr_unique_id = "co2_remaining"
     _attr_translation_key = _attr_unique_id
+    _attr_icon = "mdi:history"
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
 

--- a/custom_components/blanco_unit/sensor.py
+++ b/custom_components/blanco_unit/sensor.py
@@ -86,7 +86,6 @@ class FilterRemainingSensor(BlancoUnitBaseEntity, SensorEntity):
 
     _attr_unique_id = "filter_remaining"
     _attr_translation_key = _attr_unique_id
-    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -108,7 +107,6 @@ class CO2RemainingSensor(BlancoUnitBaseEntity, SensorEntity):
 
     _attr_unique_id = "co2_remaining"
     _attr_translation_key = _attr_unique_id
-    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
 

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -123,7 +123,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': None,
+    'original_icon': 'mdi:history',
     'original_name': 'CO2 Cylinder Remaining',
     'platform': 'blanco_unit',
     'previous_unique_id': None,
@@ -138,6 +138,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Blanco Unit CO2 Cylinder Remaining',
+      'icon': 'mdi:history',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
@@ -469,7 +470,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': None,
+    'original_icon': 'mdi:history',
     'original_name': 'Filter Capacity Remaining',
     'platform': 'blanco_unit',
     'previous_unique_id': None,
@@ -484,6 +485,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Blanco Unit Filter Capacity Remaining',
+      'icon': 'mdi:history',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -122,7 +122,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'CO2 Cylinder Remaining',
     'platform': 'blanco_unit',
@@ -137,7 +137,6 @@
 # name: test_all_entities[sensor.test_blanco_unit_co2_cylinder_remaining-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'battery',
       'friendly_name': 'Test Blanco Unit CO2 Cylinder Remaining',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
@@ -469,7 +468,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Filter Capacity Remaining',
     'platform': 'blanco_unit',
@@ -484,7 +483,6 @@
 # name: test_all_entities[sensor.test_blanco_unit_filter_capacity_remaining-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'battery',
       'friendly_name': 'Test Blanco Unit Filter Capacity Remaining',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',


### PR DESCRIPTION
As suggested in #17 tis PR removes the device_class `BATTERY` and adds the `mdi:history` icon. 